### PR TITLE
Add support for Twig ^3.21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-/.php_cs.cache
 /.php-cs-fixer.cache
+/.twig-cs-fixer.cache
+/.phpunit.result.cache
 /composer.lock
 /vendor/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.0-alpha.1 - 2026-06-22
+### Added
+- Added support for Twig 3; Twig 3.15 or later is now required
+
+### Removed
+- Dropped support for Twig 2
+
+### Fixed
+- Fixed extra whitespace left when using rule to remove names after endblock tags
+
 ## 1.1.1 - 2026-06-09
 ### Fixed
 - Prevented installation of jadu/twig-style with incompatible versions of Twig 3 where twig/twig >= 3.21.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 2.0.0-alpha.1 - 2026-06-22
+## 2.0.0-alpha.2 - 2026-07-22
 ### Added
 - Added support for Twig 3; Twig 3.15 or later is now required
+- Applied rules for block naming and spacing to macros
 
 ### Removed
 - Dropped support for Twig 2

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ vendor/bin/twig-cs-fixer lint --fix
 
 This standard is based on the [official Twig coding standards](https://twig.symfony.com/doc/3.x/coding_standards.html), with the following additions and changes:
 
-### Block spacing and new lines
+### Block and macro spacing and new lines
 
-There must be one new line before block tags and one new line after endblock tags.
+There must be one new line before block or macro tags and one new line after endblock or endmacro tags.
 
 ```twig
 
@@ -86,6 +86,13 @@ There must be one new line before block tags and one new line after endblock tag
     </div>
 {% endblock %}
 
+{% macro outer_macro() %}
+
+    {% macro inner_macro() %}
+    {% endmacro %}
+
+{% endmacro %}
+
 ```
 
 The following exceptions apply:
@@ -103,13 +110,16 @@ The following exceptions apply:
     {% block aside_container %}
     ```
 
-### Endblock names
+### Endblock and endmacro names
 
-Any `endblock` tags must be followed by the name of the block they are closing.
+Any `endblock` or `endmacro` tags must be followed by the name of the block or macro they are closing.
 
 ```twig
 {% block aside_container %}
 {% endblock aside_container %}
+
+{% macro render_widget() %}
+{% endmacro render_widget %}
 ```
 
 ### No spaceless tags

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,17 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.14.0",
-        "jadu/php-style": "^2.0.0"
+        "jadu/php-style": "^2.0.0",
+        "phpunit/phpunit": "^10.5"
     },
     "autoload": {
         "psr-4": {
             "Jadu\\Style\\Twig\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Jadu\\Style\\Twig\\Tests\\": "tests/"
         }
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "proprietary",
     "require": {
         "php": ">=8.1",
-        "vincentlanglet/twig-cs-fixer": "^2.0.0",
+        "vincentlanglet/twig-cs-fixer": "^3.0.0",
         "webmozart/assert": "^1.10.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,6 @@
         "sort-packages": true
     },
     "conflict": {
-        "twig/twig": ">=3.21.0"
+        "twig/twig": "<3.0.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,6 @@
         "sort-packages": true
     },
     "conflict": {
-        "twig/twig": "<3.0.0"
+        "twig/twig": "<3.15.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "proprietary",
     "require": {
         "php": ">=8.1",
-        "vincentlanglet/twig-cs-fixer": "^3.0.0",
+        "vincentlanglet/twig-cs-fixer": "^4.0.0",
         "webmozart/assert": "^1.10.0"
     },
     "require-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    failOnPhpunitDeprecation="true"
+>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>./src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/Rule/Block/BlockNewLineRule.php
+++ b/src/Rule/Block/BlockNewLineRule.php
@@ -6,6 +6,7 @@ namespace Jadu\Style\Twig\Rule\Block;
 
 use TwigCsFixer\Rules\AbstractFixableRule;
 use TwigCsFixer\Token\Token;
+use TwigCsFixer\Token\Tokens;
 use Webmozart\Assert\Assert;
 
 /**
@@ -20,16 +21,16 @@ final class BlockNewLineRule extends AbstractFixableRule
 {
     /**
      * @param int $tokenPosition
-     * @param array<int, Token> $tokens
+     * @param Tokens $tokens
      *
      * @return void
      */
-    protected function process(int $tokenPosition, array $tokens): void
+    protected function process(int $tokenPosition, Tokens $tokens): void
     {
-        $token = $tokens[$tokenPosition];
+        $token = $tokens->get($tokenPosition);
 
         if (
-            !$this->isTokenMatching($token, Token::BLOCK_NAME_TYPE)
+            !$token->isMatching(Token::BLOCK_NAME_TYPE)
             || !in_array($token->getValue(), ['block', 'endblock'], true)
         ) {
             return;
@@ -44,25 +45,25 @@ final class BlockNewLineRule extends AbstractFixableRule
 
     /**
      * @param int $tokenPosition
-     * @param array<int, Token> $tokens
+     * @param Tokens $tokens
      *
      * @return void
      */
-    private function checkEolBeforeBlock(int $tokenPosition, array $tokens): void
+    private function checkEolBeforeBlock(int $tokenPosition, Tokens $tokens): void
     {
-        $token = $tokens[$tokenPosition];
+        $token = $tokens->get($tokenPosition);
 
         // Find the opening {% BLOCK_START_TYPE token
-        $blockStartPosition = $this->findPrevious(Token::BLOCK_START_TYPE, $tokens, $tokenPosition - 1);
+        $blockStartPosition = $tokens->findPrevious(Token::BLOCK_START_TYPE, $tokenPosition - 1);
         // Find the token before the BLOCK_START_TYPE token, ignoring any WHITESPACE_TYPE tokens
-        $tokenBeforeBlockStartPosition = $this->findPrevious(Token::WHITESPACE_TYPE, $tokens, $blockStartPosition - 1, true);
+        $tokenBeforeBlockStartPosition = $tokens->findPrevious(Token::WHITESPACE_TYPE, $blockStartPosition - 1, 0, true);
         // If any token other than EOL is found, this is an "inline" block, so return early
-        if (!$this->isTokenMatching($tokens[$tokenBeforeBlockStartPosition], Token::EOL_TYPE)) {
+        if ($tokenBeforeBlockStartPosition !== false && !$tokens->get($tokenBeforeBlockStartPosition)->isMatching(Token::EOL_TYPE)) {
             return;
         }
 
         // Calculate the number of consecutive EOL tokens before this one by finding the previous non-EOL_TYPE token
-        $previousPosition = $this->findPrevious(Token::EOL_TYPE, $tokens, $tokenBeforeBlockStartPosition - 1, true);
+        $previousPosition = $tokens->findPrevious(Token::EOL_TYPE, $tokenBeforeBlockStartPosition - 1, 0, true);
         if (false === $previousPosition) {
             // If all previous tokens are EOL_TYPE, we have to count one more
             // since $tokenPosition starts at 0
@@ -77,7 +78,7 @@ final class BlockNewLineRule extends AbstractFixableRule
         }
 
         // Allow comments above blocks
-        if (0 === $consecutiveEolTokens && $this->isTokenMatching($tokens[$previousPosition], Token::COMMENT_END_TYPE)) {
+        if (0 === $consecutiveEolTokens && $tokens->get($previousPosition)->isMatching(Token::COMMENT_END_TYPE)) {
             return;
         }
 
@@ -108,30 +109,30 @@ final class BlockNewLineRule extends AbstractFixableRule
 
     /**
      * @param int $tokenPosition
-     * @param array<int, Token> $tokens
+     * @param Tokens $tokens
      *
      * @return void
      */
-    private function checkEolAfterEndblock(int $tokenPosition, array $tokens): void
+    private function checkEolAfterEndblock(int $tokenPosition, Tokens $tokens): void
     {
-        $token = $tokens[$tokenPosition];
+        $token = $tokens->get($tokenPosition);
 
         // Find the closing %} BLOCK_END_TYPE token
-        $blockEndPosition = $this->findNext(Token::BLOCK_END_TYPE, $tokens, $tokenPosition + 1);
+        $blockEndPosition = $tokens->findNext(Token::BLOCK_END_TYPE, $tokenPosition + 1);
         // Find the token after the BLOCK_END_TYPE token, ignoring any WHITESPACE_TYPE tokens
-        $tokenAfterBlockEndPosition = $this->findNext(Token::WHITESPACE_TYPE, $tokens, $blockEndPosition + 1, true);
+        $tokenAfterBlockEndPosition = $tokens->findNext(Token::WHITESPACE_TYPE, $blockEndPosition + 1, null, true);
         // If any token other than EOL is found, this is an "inline" block, so return early
-        if (!$this->isTokenMatching($tokens[$tokenAfterBlockEndPosition], Token::EOL_TYPE)) {
+        if (!$tokens->get($tokenAfterBlockEndPosition)->isMatching(Token::EOL_TYPE)) {
             return;
         }
 
         // Calculate the number of consecutive EOL tokens after this one by finding the next non-EOL_TYPE token
-        $nextPosition = $this->findNext(Token::EOL_TYPE, $tokens, $tokenAfterBlockEndPosition + 1, true);
+        $nextPosition = $tokens->findNext(Token::EOL_TYPE, $tokenAfterBlockEndPosition + 1, null, true);
         Assert::notFalse($nextPosition, 'An EOL_TYPE cannot be the last non-empty token');
         $consecutiveEolTokens = $nextPosition - $tokenAfterBlockEndPosition - 1;
 
         // If the EOF token is found, this is the end of file so an extra new line is not required
-        if ($this->isTokenMatching($tokens[$nextPosition], Token::EOF_TYPE)) {
+        if ($tokens->get($nextPosition)->isMatching(Token::EOF_TYPE)) {
             return;
         }
 

--- a/src/Rule/Block/BlockNewLineRule.php
+++ b/src/Rule/Block/BlockNewLineRule.php
@@ -10,7 +10,7 @@ use TwigCsFixer\Token\Tokens;
 use Webmozart\Assert\Assert;
 
 /**
- * Ensure that there is one new line before block tags and after endblock tags, with the following exceptions:
+ * Ensure that there is one new line before block and macro tags and after endblock and endmacro tags, with the following exceptions:
  * 1. Inline blocks are allowed. e.g.
  *      <body class="{% block body_classes %}{{ bodyClasses }}{% endblock %}">
  * 2. Comments on the line above block tags are allowed. e.g.
@@ -30,15 +30,15 @@ final class BlockNewLineRule extends AbstractFixableRule
         $token = $tokens->get($tokenPosition);
 
         if (
-            !$token->isMatching(Token::BLOCK_NAME_TYPE)
-            || !in_array($token->getValue(), ['block', 'endblock'], true)
+            !$token->isMatching([Token::BLOCK_NAME_TYPE, Token::MACRO_NAME_TYPE])
+            || !in_array($token->getValue(), ['block', 'macro', 'endblock', 'endmacro'], true)
         ) {
             return;
         }
 
-        if ($token->getValue() === 'block') {
+        if (in_array($token->getValue(), ['block', 'macro'], true)) {
             $this->checkEolBeforeBlock($tokenPosition, $tokens);
-        } elseif ($token->getValue() === 'endblock') {
+        } elseif (in_array($token->getValue(), ['endblock', 'endmacro'], true)) {
             $this->checkEolAfterEndblock($tokenPosition, $tokens);
         }
     }
@@ -52,6 +52,7 @@ final class BlockNewLineRule extends AbstractFixableRule
     private function checkEolBeforeBlock(int $tokenPosition, Tokens $tokens): void
     {
         $token = $tokens->get($tokenPosition);
+        $tokenName = str_starts_with($token->getValue(), 'end') ? substr($token->getValue(), 3) : $token->getValue();
 
         // Find the opening {% BLOCK_START_TYPE token
         $blockStartPosition = $tokens->findPrevious(Token::BLOCK_START_TYPE, $tokenPosition - 1);
@@ -83,7 +84,7 @@ final class BlockNewLineRule extends AbstractFixableRule
         }
 
         $fixer = $this->addFixableError(
-            sprintf('A block must start with 1 new line; found %d', $consecutiveEolTokens),
+            sprintf('A %s must start with 1 new line; found %d', $tokenName, $consecutiveEolTokens),
             $token
         );
 
@@ -116,6 +117,7 @@ final class BlockNewLineRule extends AbstractFixableRule
     private function checkEolAfterEndblock(int $tokenPosition, Tokens $tokens): void
     {
         $token = $tokens->get($tokenPosition);
+        $tokenName = str_starts_with($token->getValue(), 'end') ? substr($token->getValue(), 3) : $token->getValue();
 
         // Find the closing %} BLOCK_END_TYPE token
         $blockEndPosition = $tokens->findNext(Token::BLOCK_END_TYPE, $tokenPosition + 1);
@@ -142,7 +144,7 @@ final class BlockNewLineRule extends AbstractFixableRule
         }
 
         $fixer = $this->addFixableError(
-            sprintf('A block must end with 1 new line; found %d', $consecutiveEolTokens),
+            sprintf('A %s must end with 1 new line; found %d', $tokenName, $consecutiveEolTokens),
             $token
         );
 

--- a/src/Rule/Block/EndblockNameRule.php
+++ b/src/Rule/Block/EndblockNameRule.php
@@ -103,7 +103,7 @@ final class EndblockNameRule extends AbstractFixableRule
 
         $nextPosition = $tokenPosition + 1;
         while (!$tokens->get($nextPosition)->isMatching(Token::BLOCK_END_TYPE)) {
-            if ($tokens->get($nextPosition)->isMatching([Token::NAME_TYPE, Token::FILTER_NAME_TYPE, Token::FUNCTION_NAME_TYPE, Token::TEST_NAME_TYPE])) {
+            if ($tokens->get($nextPosition)->isMatching([Token::NAME_TYPE])) {
                 return $nextPosition;
             }
             ++$nextPosition;

--- a/src/Rule/Block/EndblockNameRule.php
+++ b/src/Rule/Block/EndblockNameRule.php
@@ -10,7 +10,7 @@ use TwigCsFixer\Token\Tokens;
 use Webmozart\Assert\Assert;
 
 /**
- * Ensure that an endblock tag has the name of the corresponding block tag.
+ * Ensure that an endblock or endmacro tag has the name of the corresponding block or macro tag.
  */
 final class EndblockNameRule extends AbstractFixableRule
 {
@@ -25,12 +25,15 @@ final class EndblockNameRule extends AbstractFixableRule
         $token = $tokens->get($tokenPosition);
 
         if (
-            $token->isMatching(Token::BLOCK_NAME_TYPE)
-            && $token->getValue() === 'endblock'
+            $token->isMatching([Token::BLOCK_NAME_TYPE, Token::MACRO_NAME_TYPE])
+            && in_array($token->getValue(), ['endblock', 'endmacro'], true)
         ) {
+            $tokenName = $token->getValue();
+            $pairedTokenName = str_starts_with($tokenName, 'end') ? substr($tokenName, 3) : $tokenName;
+
             $matchingBlockTokenPosition = $this->getMatchingBlockTokenPositionForEndblockToken($tokenPosition, $tokens);
             if (!$matchingBlockTokenPosition) {
-                $this->addError('Could not find matching block tag for endblock tag', $token);
+                $this->addError(sprintf('Could not find matching %s tag for %s tag', $pairedTokenName, $tokenName), $token);
 
                 return;
             }
@@ -41,14 +44,14 @@ final class EndblockNameRule extends AbstractFixableRule
             $nameAfterEndblockToken = ($nameAfterEndblockTokenPosition !== false) ? $tokens->get($nameAfterEndblockTokenPosition)->getValue() : null;
 
             if (!$nameAfterBlockToken && !$nameAfterEndblockToken) {
-                $this->addError('Missing block name and endblock name', $token);
+                $this->addError(sprintf('Missing %s name and %s name', $pairedTokenName, $tokenName), $token);
 
                 return;
             }
 
             if (!$nameAfterBlockToken && $nameAfterEndblockToken) {
                 $this->addError(
-                    sprintf('Missing block name "%s"', $nameAfterEndblockToken),
+                    sprintf('Missing %s name "%s"', $pairedTokenName, $nameAfterEndblockToken),
                     $tokens->get($matchingBlockTokenPosition)
                 );
 
@@ -57,12 +60,12 @@ final class EndblockNameRule extends AbstractFixableRule
 
             if ($nameAfterBlockToken && !$nameAfterEndblockToken) {
                 $fixer = $this->addFixableError(
-                    sprintf('Missing endblock name "%s"', $nameAfterBlockToken),
+                    sprintf('Missing %s name "%s"', $tokenName, $nameAfterBlockToken),
                     $token
                 );
             } elseif ($nameAfterBlockToken !== $nameAfterEndblockToken) {
                 $fixer = $this->addFixableError(
-                    sprintf('Mismatching block name "%s" and endblock name "%s"', $nameAfterBlockToken, $nameAfterEndblockToken),
+                    sprintf('Mismatching %s name "%s" and %s name "%s"', $tokenName, $nameAfterBlockToken, $pairedTokenName, $nameAfterEndblockToken),
                     $token
                 );
             } else {
@@ -80,7 +83,7 @@ final class EndblockNameRule extends AbstractFixableRule
             if ($nameAfterEndblockTokenPosition !== false) {
                 $fixer->replaceToken($nameAfterEndblockTokenPosition, $nameAfterBlockToken);
             } else {
-                $fixer->replaceToken($tokenPosition, sprintf('endblock %s', $nameAfterBlockToken));
+                $fixer->replaceToken($tokenPosition, sprintf('%s %s', $token->getValue(), $nameAfterBlockToken));
             }
         }
     }
@@ -103,7 +106,7 @@ final class EndblockNameRule extends AbstractFixableRule
 
         $nextPosition = $tokenPosition + 1;
         while (!$tokens->get($nextPosition)->isMatching(Token::BLOCK_END_TYPE)) {
-            if ($tokens->get($nextPosition)->isMatching([Token::NAME_TYPE])) {
+            if ($tokens->get($nextPosition)->isMatching([Token::NAME_TYPE, Token::MACRO_NAME_TYPE])) {
                 return $nextPosition;
             }
             ++$nextPosition;
@@ -122,19 +125,19 @@ final class EndblockNameRule extends AbstractFixableRule
     {
         $token = $tokens->get($tokenPosition);
 
-        if (!$token->isMatching(Token::BLOCK_NAME_TYPE) || $token->getValue() !== 'endblock') {
+        if (!$token->isMatching([Token::BLOCK_NAME_TYPE, Token::MACRO_NAME_TYPE]) || !in_array($token->getValue(), ['endblock', 'endmacro'], true)) {
             return false;
         }
 
         $previousPosition = $tokenPosition - 1;
         $blocks = 0;
         $endblocks = 1;
-        // When $blocks === $endblocks we have found the matching block token for the original endblock token
-        while ($blocks !== $endblocks && false !== ($previousPosition = $tokens->findPrevious(Token::BLOCK_NAME_TYPE, $previousPosition))) {
+        // When $blocks === $endblocks we have found the matching block token for the original endblock or endmacro token
+        while ($blocks !== $endblocks && false !== ($previousPosition = $tokens->findPrevious([Token::BLOCK_NAME_TYPE, Token::MACRO_NAME_TYPE], $previousPosition))) {
             $previousBlockToken = $tokens->get($previousPosition);
-            if ($previousBlockToken->getValue() === 'block') {
+            if (in_array($previousBlockToken->getValue(), ['block', 'macro'])) {
                 ++$blocks;
-            } elseif ($previousBlockToken->getValue() === 'endblock') {
+            } elseif (in_array($previousBlockToken->getValue(), ['endblock', 'endmacro'], true)) {
                 ++$endblocks;
             }
             --$previousPosition;

--- a/src/Rule/Block/EndblockNameRule.php
+++ b/src/Rule/Block/EndblockNameRule.php
@@ -6,6 +6,7 @@ namespace Jadu\Style\Twig\Rule\Block;
 
 use TwigCsFixer\Rules\AbstractFixableRule;
 use TwigCsFixer\Token\Token;
+use TwigCsFixer\Token\Tokens;
 use Webmozart\Assert\Assert;
 
 /**
@@ -15,16 +16,16 @@ final class EndblockNameRule extends AbstractFixableRule
 {
     /**
      * @param int $tokenPosition
-     * @param array<int, Token> $tokens
+     * @param Tokens $tokens
      *
      * @return void
      */
-    protected function process(int $tokenPosition, array $tokens): void
+    protected function process(int $tokenPosition, Tokens $tokens): void
     {
-        $token = $tokens[$tokenPosition];
+        $token = $tokens->get($tokenPosition);
 
         if (
-            $this->isTokenMatching($token, Token::BLOCK_NAME_TYPE)
+            $token->isMatching(Token::BLOCK_NAME_TYPE)
             && $token->getValue() === 'endblock'
         ) {
             $matchingBlockTokenPosition = $this->getMatchingBlockTokenPositionForEndblockToken($tokenPosition, $tokens);
@@ -35,9 +36,9 @@ final class EndblockNameRule extends AbstractFixableRule
             }
 
             $nameAfterBlockTokenPosition = $this->getNameTokenPositionAfterBlockToken($matchingBlockTokenPosition, $tokens);
-            $nameAfterBlockToken = ($nameAfterBlockTokenPosition !== false) ? $tokens[$nameAfterBlockTokenPosition]->getValue() : null;
+            $nameAfterBlockToken = ($nameAfterBlockTokenPosition !== false) ? $tokens->get($nameAfterBlockTokenPosition)->getValue() : null;
             $nameAfterEndblockTokenPosition = $this->getNameTokenPositionAfterBlockToken($tokenPosition, $tokens);
-            $nameAfterEndblockToken = ($nameAfterEndblockTokenPosition !== false) ? $tokens[$nameAfterEndblockTokenPosition]->getValue() : null;
+            $nameAfterEndblockToken = ($nameAfterEndblockTokenPosition !== false) ? $tokens->get($nameAfterEndblockTokenPosition)->getValue() : null;
 
             if (!$nameAfterBlockToken && !$nameAfterEndblockToken) {
                 $this->addError('Missing block name and endblock name', $token);
@@ -48,7 +49,7 @@ final class EndblockNameRule extends AbstractFixableRule
             if (!$nameAfterBlockToken && $nameAfterEndblockToken) {
                 $this->addError(
                     sprintf('Missing block name "%s"', $nameAfterEndblockToken),
-                    $tokens[$matchingBlockTokenPosition]
+                    $tokens->get($matchingBlockTokenPosition)
                 );
 
                 return;
@@ -86,23 +87,23 @@ final class EndblockNameRule extends AbstractFixableRule
 
     /**
      * @param int $tokenPosition
-     * @param array<int, Token> $tokens
+     * @param Tokens $tokens
      *
      * @return int|false
      */
-    private function getNameTokenPositionAfterBlockToken(int $tokenPosition, array $tokens): int|false
+    private function getNameTokenPositionAfterBlockToken(int $tokenPosition, Tokens $tokens): int|false
     {
-        $token = $tokens[$tokenPosition];
+        $token = $tokens->get($tokenPosition);
 
         // Ignore new line
-        $next = $this->findNext(Token::INDENT_TOKENS, $tokens, $tokenPosition + 1, true);
-        if (false === $next || $this->isTokenMatching($tokens[$next], Token::EOL_TOKENS)) {
+        $next = $tokens->findNext(Token::INDENT_TOKENS, $tokenPosition + 1, null, true);
+        if (false === $next || $tokens->get($next)->isMatching(Token::EOL_TOKENS)) {
             return false;
         }
 
         $nextPosition = $tokenPosition + 1;
-        while (!$this->isTokenMatching($tokens[$nextPosition], Token::BLOCK_END_TYPE)) {
-            if ($this->isTokenMatching($tokens[$nextPosition], Token::NAME_TYPE)) {
+        while (!$tokens->get($nextPosition)->isMatching(Token::BLOCK_END_TYPE)) {
+            if ($tokens->get($nextPosition)->isMatching([Token::NAME_TYPE, Token::FILTER_NAME_TYPE, Token::FUNCTION_NAME_TYPE, Token::TEST_NAME_TYPE])) {
                 return $nextPosition;
             }
             ++$nextPosition;
@@ -113,15 +114,15 @@ final class EndblockNameRule extends AbstractFixableRule
 
     /**
      * @param int $tokenPosition
-     * @param array<int, Token> $tokens
+     * @param Tokens $tokens
      *
      * @return int|false
      */
-    private function getMatchingBlockTokenPositionForEndblockToken(int $tokenPosition, array $tokens): int|false
+    private function getMatchingBlockTokenPositionForEndblockToken(int $tokenPosition, Tokens $tokens): int|false
     {
-        $token = $tokens[$tokenPosition];
+        $token = $tokens->get($tokenPosition);
 
-        if (!$this->isTokenMatching($token, Token::BLOCK_NAME_TYPE) || $token->getValue() !== 'endblock') {
+        if (!$token->isMatching(Token::BLOCK_NAME_TYPE) || $token->getValue() !== 'endblock') {
             return false;
         }
 
@@ -129,8 +130,8 @@ final class EndblockNameRule extends AbstractFixableRule
         $blocks = 0;
         $endblocks = 1;
         // When $blocks === $endblocks we have found the matching block token for the original endblock token
-        while ($blocks !== $endblocks && false !== ($previousPosition = $this->findPrevious(Token::BLOCK_NAME_TYPE, $tokens, $previousPosition))) {
-            $previousBlockToken = $tokens[$previousPosition];
+        while ($blocks !== $endblocks && false !== ($previousPosition = $tokens->findPrevious(Token::BLOCK_NAME_TYPE, $previousPosition))) {
+            $previousBlockToken = $tokens->get($previousPosition);
             if ($previousBlockToken->getValue() === 'block') {
                 ++$blocks;
             } elseif ($previousBlockToken->getValue() === 'endblock') {

--- a/src/Rule/Block/NoEndblockNameRule.php
+++ b/src/Rule/Block/NoEndblockNameRule.php
@@ -57,7 +57,10 @@ final class NoEndblockNameRule extends AbstractFixableRule
                 return;
             }
 
-            $fixer->replaceToken($nextPosition, '');
+            while (!$tokens->get($nextPosition)->isMatching(Token::BLOCK_END_TYPE)) {
+                $fixer->replaceToken($nextPosition, '');
+                ++$nextPosition;
+            }
         }
     }
 }

--- a/src/Rule/Block/NoEndblockNameRule.php
+++ b/src/Rule/Block/NoEndblockNameRule.php
@@ -36,7 +36,7 @@ final class NoEndblockNameRule extends AbstractFixableRule
             $error = false;
             $nextPosition = $tokenPosition + 1;
             while (!$tokens->get($nextPosition)->isMatching(Token::BLOCK_END_TYPE)) {
-                $error = $tokens->get($nextPosition)->isMatching([Token::NAME_TYPE, Token::FILTER_NAME_TYPE, Token::FUNCTION_NAME_TYPE, Token::TEST_NAME_TYPE]);
+                $error = $tokens->get($nextPosition)->isMatching([Token::NAME_TYPE]);
                 if ($error) {
                     $fixer = $this->addFixableError(
                         sprintf('Unexpected block name "%s" after %s', $tokens->get($nextPosition)->getValue(), $token->getValue()),

--- a/src/Rule/Block/NoEndblockNameRule.php
+++ b/src/Rule/Block/NoEndblockNameRule.php
@@ -9,7 +9,7 @@ use TwigCsFixer\Token\Token;
 use TwigCsFixer\Token\Tokens;
 
 /**
- * Ensure that an endblock tag has no name.
+ * Ensure that an endblock or endmacro tag has no name.
  */
 final class NoEndblockNameRule extends AbstractFixableRule
 {
@@ -24,8 +24,8 @@ final class NoEndblockNameRule extends AbstractFixableRule
         $token = $tokens->get($tokenPosition);
 
         if (
-            $token->isMatching(Token::BLOCK_NAME_TYPE)
-            && $token->getValue() === 'endblock'
+            $token->isMatching([Token::BLOCK_NAME_TYPE, Token::MACRO_NAME_TYPE])
+            && in_array($token->getValue(), ['endblock', 'endmacro'], true)
         ) {
             // Ignore new line
             $next = $tokens->findNext(Token::INDENT_TOKENS, $tokenPosition + 1, null, true);
@@ -33,13 +33,16 @@ final class NoEndblockNameRule extends AbstractFixableRule
                 return;
             }
 
+            $tokenName = $token->getValue();
+            $pairedTokenName = str_starts_with($tokenName, 'end') ? substr($tokenName, 3) : $tokenName;
+
             $error = false;
             $nextPosition = $tokenPosition + 1;
             while (!$tokens->get($nextPosition)->isMatching(Token::BLOCK_END_TYPE)) {
-                $error = $tokens->get($nextPosition)->isMatching([Token::NAME_TYPE]);
+                $error = $tokens->get($nextPosition)->isMatching([Token::NAME_TYPE, Token::MACRO_NAME_TYPE]);
                 if ($error) {
                     $fixer = $this->addFixableError(
-                        sprintf('Unexpected block name "%s" after %s', $tokens->get($nextPosition)->getValue(), $token->getValue()),
+                        sprintf('Unexpected %s name "%s" after %s', $pairedTokenName, $tokens->get($nextPosition)->getValue(), $tokenName),
                         $token
                     );
                     break;

--- a/src/Rule/Block/NoEndblockNameRule.php
+++ b/src/Rule/Block/NoEndblockNameRule.php
@@ -6,6 +6,7 @@ namespace Jadu\Style\Twig\Rule\Block;
 
 use TwigCsFixer\Rules\AbstractFixableRule;
 use TwigCsFixer\Token\Token;
+use TwigCsFixer\Token\Tokens;
 
 /**
  * Ensure that an endblock tag has no name.
@@ -14,31 +15,31 @@ final class NoEndblockNameRule extends AbstractFixableRule
 {
     /**
      * @param int $tokenPosition
-     * @param array<int, Token> $tokens
+     * @param Tokens $tokens
      *
      * @return void
      */
-    protected function process(int $tokenPosition, array $tokens): void
+    protected function process(int $tokenPosition, Tokens $tokens): void
     {
-        $token = $tokens[$tokenPosition];
+        $token = $tokens->get($tokenPosition);
 
         if (
-            $this->isTokenMatching($token, Token::BLOCK_NAME_TYPE)
+            $token->isMatching(Token::BLOCK_NAME_TYPE)
             && $token->getValue() === 'endblock'
         ) {
             // Ignore new line
-            $next = $this->findNext(Token::INDENT_TOKENS, $tokens, $tokenPosition + 1, true);
-            if (false === $next || $this->isTokenMatching($tokens[$next], Token::EOL_TOKENS)) {
+            $next = $tokens->findNext(Token::INDENT_TOKENS, $tokenPosition + 1, null, true);
+            if (false === $next || $tokens->get($next)->isMatching(Token::EOL_TOKENS)) {
                 return;
             }
 
             $error = false;
             $nextPosition = $tokenPosition + 1;
-            while (!$this->isTokenMatching($tokens[$nextPosition], Token::BLOCK_END_TYPE)) {
-                $error = $this->isTokenMatching($tokens[$nextPosition], Token::NAME_TYPE);
+            while (!$tokens->get($nextPosition)->isMatching(Token::BLOCK_END_TYPE)) {
+                $error = $tokens->get($nextPosition)->isMatching([Token::NAME_TYPE, Token::FILTER_NAME_TYPE, Token::FUNCTION_NAME_TYPE, Token::TEST_NAME_TYPE]);
                 if ($error) {
                     $fixer = $this->addFixableError(
-                        sprintf('Unexpected block name "%s" after %s', $tokens[$nextPosition]->getValue(), $token->getValue()),
+                        sprintf('Unexpected block name "%s" after %s', $tokens->get($nextPosition)->getValue(), $token->getValue()),
                         $token
                     );
                     break;

--- a/src/Rule/Development/TokenTypeRule.php
+++ b/src/Rule/Development/TokenTypeRule.php
@@ -7,6 +7,7 @@ namespace Jadu\Style\Twig\Rule\Development;
 use ReflectionClass;
 use TwigCsFixer\Rules\AbstractRule;
 use TwigCsFixer\Token\Token;
+use TwigCsFixer\Token\Tokens;
 
 /**
  * This rule is intended for development purposes only.
@@ -17,13 +18,13 @@ final class TokenTypeRule extends AbstractRule
 {
     /**
      * @param int $tokenPosition
-     * @param array<int, Token> $tokens
+     * @param Tokens $tokens
      *
      * @return void
      */
-    protected function process(int $tokenPosition, array $tokens): void
+    protected function process(int $tokenPosition, Tokens $tokens): void
     {
-        $token = $tokens[$tokenPosition];
+        $token = $tokens->get($tokenPosition);
 
         $tokenClass = new ReflectionClass(Token::class);
         $tokenTypeName = array_search($token->getType(), $tokenClass->getConstants());

--- a/src/Rule/Filter/NoFilterTagRule.php
+++ b/src/Rule/Filter/NoFilterTagRule.php
@@ -6,6 +6,7 @@ namespace Jadu\Style\Twig\Rule\Filter;
 
 use TwigCsFixer\Rules\AbstractFixableRule;
 use TwigCsFixer\Token\Token;
+use TwigCsFixer\Token\Tokens;
 
 /**
  * Replaces usages of the {% filter %} tag with {% apply %}.
@@ -15,17 +16,17 @@ final class NoFilterTagRule extends AbstractFixableRule
 {
     /**
      * @param int $tokenPosition
-     * @param array<int, Token> $tokens
+     * @param Tokens $tokens
      *
      * @return void
      */
-    protected function process(int $tokenPosition, array $tokens): void
+    protected function process(int $tokenPosition, Tokens $tokens): void
     {
-        $token = $tokens[$tokenPosition];
+        $token = $tokens->get($tokenPosition);
 
         $error = false;
         if (
-            $this->isTokenMatching($token, Token::BLOCK_NAME_TYPE)
+            $token->isMatching(Token::BLOCK_NAME_TYPE)
             && in_array($token->getValue(), ['filter', 'endfilter'], true)
         ) {
             $error = true;

--- a/src/Rule/Filter/NoSpacelessTagRule.php
+++ b/src/Rule/Filter/NoSpacelessTagRule.php
@@ -6,6 +6,7 @@ namespace Jadu\Style\Twig\Rule\Filter;
 
 use TwigCsFixer\Rules\AbstractFixableRule;
 use TwigCsFixer\Token\Token;
+use TwigCsFixer\Token\Tokens;
 
 /**
  * Replaces usages of the {% spaceless %} tag with {% apply spaceless %}.
@@ -15,17 +16,17 @@ final class NoSpacelessTagRule extends AbstractFixableRule
 {
     /**
      * @param int $tokenPosition
-     * @param array<int, Token> $tokens
+     * @param Tokens $tokens
      *
      * @return void
      */
-    protected function process(int $tokenPosition, array $tokens): void
+    protected function process(int $tokenPosition, Tokens $tokens): void
     {
-        $token = $tokens[$tokenPosition];
+        $token = $tokens->get($tokenPosition);
 
         $error = false;
         if (
-            $this->isTokenMatching($token, Token::BLOCK_NAME_TYPE)
+            $token->isMatching(Token::BLOCK_NAME_TYPE)
             && in_array($token->getValue(), ['spaceless', 'endspaceless'], true)
         ) {
             $error = true;

--- a/src/Rule/Punctuation/PunctuationSpacingRule.php
+++ b/src/Rule/Punctuation/PunctuationSpacingRule.php
@@ -6,6 +6,7 @@ namespace Jadu\Style\Twig\Rule\Punctuation;
 
 use TwigCsFixer\Rules\AbstractSpacingRule;
 use TwigCsFixer\Token\Token;
+use TwigCsFixer\Token\Tokens;
 use Webmozart\Assert\Assert;
 
 /**
@@ -38,25 +39,25 @@ final class PunctuationSpacingRule extends AbstractSpacingRule
 
     /**
      * @param int $tokenPosition
-     * @param array<int, Token> $tokens
+     * @param Tokens $tokens
      *
      * @return int|null
      */
-    protected function getSpaceBefore(int $tokenPosition, array $tokens): ?int
+    protected function getSpaceBefore(int $tokenPosition, Tokens $tokens): ?int
     {
-        $token = $tokens[$tokenPosition];
+        $token = $tokens->get($tokenPosition);
 
-        if (!$this->isTokenMatching($token, Token::PUNCTUATION_TYPE)) {
+        if (!$token->isMatching(Token::PUNCTUATION_TYPE)) {
             return null;
         }
 
-        $previousPosition = $this->findPrevious(Token::WHITESPACE_TOKENS, $tokens, $tokenPosition - 1, true);
+        $previousPosition = $tokens->findPrevious(Token::WHITESPACE_TOKENS, $tokenPosition - 1, 0, true);
         if (false === $previousPosition) {
             return null;
         }
 
         // Always remove spaces for empty arrays, hashes, and parentheses
-        $previousToken = $tokens[$previousPosition];
+        $previousToken = $tokens->get($previousPosition);
         if ($this->getPairedTokens($previousToken, $token)) {
             return 0;
         }
@@ -66,23 +67,23 @@ final class PunctuationSpacingRule extends AbstractSpacingRule
 
     /**
      * @param int $tokenPosition
-     * @param array<int, Token> $tokens
+     * @param Tokens $tokens
      *
      * @return int|null
      */
-    protected function getSpaceAfter(int $tokenPosition, array $tokens): ?int
+    protected function getSpaceAfter(int $tokenPosition, Tokens $tokens): ?int
     {
-        $token = $tokens[$tokenPosition];
+        $token = $tokens->get($tokenPosition);
 
-        if (!$this->isTokenMatching($token, Token::PUNCTUATION_TYPE)) {
+        if (!$token->isMatching(Token::PUNCTUATION_TYPE)) {
             return null;
         }
 
-        $nextPosition = $this->findNext(Token::WHITESPACE_TOKENS, $tokens, $tokenPosition + 1, true);
+        $nextPosition = $tokens->findNext(Token::WHITESPACE_TOKENS, $tokenPosition + 1, null, true);
         Assert::notFalse($nextPosition, 'A PUNCTUATION_TYPE cannot be the last non-empty token');
 
         // Always remove spaces for empty arrays, hashes, and parentheses
-        $nextToken = $tokens[$nextPosition];
+        $nextToken = $tokens->get($nextPosition);
         if ($this->getPairedTokens($token, $nextToken)) {
             return 0;
         }

--- a/src/Rule/Punctuation/PunctuationSpacingRule.php
+++ b/src/Rule/Punctuation/PunctuationSpacingRule.php
@@ -22,9 +22,7 @@ final class PunctuationSpacingRule extends AbstractSpacingRule
         ']' => 0,
         '}' => 1,
         ':' => 0,
-        '.' => 0,
         ',' => 0,
-        '|' => 0,
         '?:' => 1,
     ];
 
@@ -32,8 +30,6 @@ final class PunctuationSpacingRule extends AbstractSpacingRule
         '(' => 0,
         '[' => 0,
         '{' => 1,
-        '.' => 0,
-        '|' => 0,
         ':' => 1,
         ',' => 1,
         '?:' => 1,

--- a/src/Rule/Punctuation/PunctuationSpacingRule.php
+++ b/src/Rule/Punctuation/PunctuationSpacingRule.php
@@ -10,7 +10,7 @@ use TwigCsFixer\Token\Tokens;
 use Webmozart\Assert\Assert;
 
 /**
- * Ensure there is no space before and after punctuation except for '{', '}', ':', and ','.
+ * Ensure there is no space before and after punctuation except for '{', '}', ':', ',', and '?:'.
  * No spaces are allowed between "paired" tokens such as arrays, hashes, and parentheses when they are empty.
  *
  * @see \TwigCsFixer\Rules\Punctuation\PunctuationSpacingRule
@@ -25,6 +25,7 @@ final class PunctuationSpacingRule extends AbstractSpacingRule
         '.' => 0,
         ',' => 0,
         '|' => 0,
+        '?:' => 1,
     ];
 
     private const SPACE_AFTER = [
@@ -35,6 +36,7 @@ final class PunctuationSpacingRule extends AbstractSpacingRule
         '|' => 0,
         ':' => 1,
         ',' => 1,
+        '?:' => 1,
     ];
 
     /**

--- a/src/Standard/JaduStandard.php
+++ b/src/Standard/JaduStandard.php
@@ -11,6 +11,8 @@ use TwigCsFixer\Rules\Delimiter\BlockNameSpacingRule;
 use TwigCsFixer\Rules\Delimiter\DelimiterSpacingRule;
 use TwigCsFixer\Rules\Operator\OperatorNameSpacingRule;
 use TwigCsFixer\Rules\Operator\OperatorSpacingRule;
+use TwigCsFixer\Rules\Operator\TernaryOperatorSpacingRule;
+use TwigCsFixer\Rules\Operator\UnaryOperatorSpacingRule;
 use TwigCsFixer\Rules\Punctuation\TrailingCommaSingleLineRule;
 use TwigCsFixer\Rules\RuleInterface;
 use TwigCsFixer\Rules\Whitespace\BlankEOFRule;
@@ -38,9 +40,11 @@ class JaduStandard implements StandardInterface
             new NoFilterTagRule(),
             new OperatorNameSpacingRule(),
             new OperatorSpacingRule(),
+            new TernaryOperatorSpacingRule(),
             new PunctuationSpacingRule(),
             new TrailingCommaSingleLineRule(),
             new TrailingSpaceRule(),
+            new UnaryOperatorSpacingRule(),
         ];
     }
 }

--- a/tests/Rule/Block/BlockNewLineRuleTest.fixed.twig
+++ b/tests/Rule/Block/BlockNewLineRuleTest.fixed.twig
@@ -1,0 +1,24 @@
+{% block aside %}
+    <div class="aside">
+
+        {% block aside_inner %}
+            {# Blocks related to primary supplements #}
+            {% block before_primary_supplements %}
+            {% endblock %}
+
+            {% block primary_supplements %}
+            {% endblock %}
+
+            {% block after_primary_supplements %}
+            {% endblock %}
+
+        {% endblock %}
+
+    </div>
+{% endblock %}
+
+<body class="{% block body_classes %}{{ bodyClasses }}{% endblock %}">
+
+{# This block adds a container around the aside #}
+{% block aside_container %}
+{% endblock %}

--- a/tests/Rule/Block/BlockNewLineRuleTest.fixed.twig
+++ b/tests/Rule/Block/BlockNewLineRuleTest.fixed.twig
@@ -22,3 +22,13 @@
 {# This block adds a container around the aside #}
 {% block aside_container %}
 {% endblock %}
+
+{% macro test() %}
+{% endmacro %}
+
+{% macro outer_macro() %}
+
+    {% macro inner_macro() %}
+    {% endmacro %}
+
+{% endmacro %}

--- a/tests/Rule/Block/BlockNewLineRuleTest.php
+++ b/tests/Rule/Block/BlockNewLineRuleTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jadu\Style\Twig\Tests\Rules\Block;
+
+use Jadu\Style\Twig\Rule\Block\BlockNewLineRule;
+use TwigCsFixer\Test\AbstractRuleTestCase;
+
+final class BlockNewLineRuleTest extends AbstractRuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->checkRule(new BlockNewLineRule(), [
+            'BlockNewLine.Error:3:12' => 'A block must start with 1 new line; found 0',
+            'BlockNewLine.Error:6:16' => 'A block must end with 1 new line; found 0',
+            'BlockNewLine.Error:7:16' => 'A block must start with 1 new line; found 0',
+            'BlockNewLine.Error:8:16' => 'A block must end with 1 new line; found 0',
+            'BlockNewLine.Error:9:16' => 'A block must start with 1 new line; found 0',
+            'BlockNewLine.Error:10:16' => 'A block must end with 1 new line; found 0',
+            'BlockNewLine.Error:11:12' => 'A block must end with 1 new line; found 0',
+        ]);
+    }
+}

--- a/tests/Rule/Block/BlockNewLineRuleTest.php
+++ b/tests/Rule/Block/BlockNewLineRuleTest.php
@@ -19,6 +19,10 @@ final class BlockNewLineRuleTest extends AbstractRuleTestCase
             'BlockNewLine.Error:9:16' => 'A block must start with 1 new line; found 0',
             'BlockNewLine.Error:10:16' => 'A block must end with 1 new line; found 0',
             'BlockNewLine.Error:11:12' => 'A block must end with 1 new line; found 0',
+            'BlockNewLine.Error:22:4' => 'A macro must end with 1 new line; found 0',
+            'BlockNewLine.Error:23:4' => 'A macro must start with 1 new line; found 0',
+            'BlockNewLine.Error:24:8' => 'A macro must start with 1 new line; found 0',
+            'BlockNewLine.Error:25:8' => 'A macro must end with 1 new line; found 0',
         ]);
     }
 }

--- a/tests/Rule/Block/BlockNewLineRuleTest.twig
+++ b/tests/Rule/Block/BlockNewLineRuleTest.twig
@@ -17,3 +17,10 @@
 {# This block adds a container around the aside #}
 {% block aside_container %}
 {% endblock %}
+
+{% macro test() %}
+{% endmacro %}
+{% macro outer_macro() %}
+    {% macro inner_macro() %}
+    {% endmacro %}
+{% endmacro %}

--- a/tests/Rule/Block/BlockNewLineRuleTest.twig
+++ b/tests/Rule/Block/BlockNewLineRuleTest.twig
@@ -1,0 +1,19 @@
+{% block aside %}
+    <div class="aside">
+        {% block aside_inner %}
+            {# Blocks related to primary supplements #}
+            {% block before_primary_supplements %}
+            {% endblock %}
+            {% block primary_supplements %}
+            {% endblock %}
+            {% block after_primary_supplements %}
+            {% endblock %}
+        {% endblock %}
+    </div>
+{% endblock %}
+
+<body class="{% block body_classes %}{{ bodyClasses }}{% endblock %}">
+
+{# This block adds a container around the aside #}
+{% block aside_container %}
+{% endblock %}

--- a/tests/Rule/Block/EndblockNameRuleTest.fixed.twig
+++ b/tests/Rule/Block/EndblockNameRuleTest.fixed.twig
@@ -22,3 +22,19 @@
 {# This block adds a container around the aside #}
 {% block aside_container %}
 {% endblock aside_container %}
+
+{% macro test() %}
+{% endmacro test %}
+{% macro outer_macro() %}
+    {% macro inner_macro() %}
+    {% endmacro inner_macro %}
+{% endmacro outer_macro %}
+
+{% block badges %}
+    {% macro render_badge(text) %}
+        <span class="badge">{{ text }}</span>
+    {% endmacro render_badge %}
+
+    {{ _self.render_badge('Live') }}
+    {{ _self.render_badge('Offline') }}
+{% endblock badges %}

--- a/tests/Rule/Block/EndblockNameRuleTest.fixed.twig
+++ b/tests/Rule/Block/EndblockNameRuleTest.fixed.twig
@@ -1,0 +1,24 @@
+{% block aside %}
+    <div class="aside">
+
+        {% block aside_inner %}
+
+            {% block before_primary_supplements %}
+            {% endblock before_primary_supplements %}
+
+            {% block primary_supplements %}
+            {% endblock primary_supplements %}
+
+            {% block after_primary_supplements %}
+            {% endblock after_primary_supplements %}
+
+        {% endblock aside_inner %}
+
+    </div>
+{% endblock aside %}
+
+<body class="{% block body_classes %}{{ bodyClasses }}{% endblock body_classes %}">
+
+{# This block adds a container around the aside #}
+{% block aside_container %}
+{% endblock aside_container %}

--- a/tests/Rule/Block/EndblockNameRuleTest.php
+++ b/tests/Rule/Block/EndblockNameRuleTest.php
@@ -19,6 +19,11 @@ final class EndblockNameRuleTest extends AbstractRuleTestCase
             'EndblockName.Error:18:4' => 'Missing endblock name "aside"',
             'EndblockName.Error:20:58' => 'Missing endblock name "body_classes"',
             'EndblockName.Error:24:4' => 'Missing endblock name "aside_container"',
+            'EndblockName.Error:27:4' => 'Missing endmacro name "test"',
+            'EndblockName.Error:30:8' => 'Missing endmacro name "inner_macro"',
+            'EndblockName.Error:31:4' => 'Missing endmacro name "outer_macro"',
+            'EndblockName.Error:36:8' => 'Missing endmacro name "render_badge"',
+            'EndblockName.Error:40:4' => 'Missing endblock name "badges"',
         ]);
     }
 }

--- a/tests/Rule/Block/EndblockNameRuleTest.php
+++ b/tests/Rule/Block/EndblockNameRuleTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jadu\Style\Twig\Tests\Rules\Block;
+
+use Jadu\Style\Twig\Rule\Block\EndblockNameRule;
+use TwigCsFixer\Test\AbstractRuleTestCase;
+
+final class EndblockNameRuleTest extends AbstractRuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->checkRule(new EndblockNameRule(), [
+            'EndblockName.Error:7:16' => 'Missing endblock name "before_primary_supplements"',
+            'EndblockName.Error:10:16' => 'Missing endblock name "primary_supplements"',
+            'EndblockName.Error:13:16' => 'Missing endblock name "after_primary_supplements"',
+            'EndblockName.Error:15:12' => 'Missing endblock name "aside_inner"',
+            'EndblockName.Error:18:4' => 'Missing endblock name "aside"',
+            'EndblockName.Error:20:58' => 'Missing endblock name "body_classes"',
+            'EndblockName.Error:24:4' => 'Missing endblock name "aside_container"',
+        ]);
+    }
+}

--- a/tests/Rule/Block/EndblockNameRuleTest.twig
+++ b/tests/Rule/Block/EndblockNameRuleTest.twig
@@ -1,0 +1,24 @@
+{% block aside %}
+    <div class="aside">
+
+        {% block aside_inner %}
+
+            {% block before_primary_supplements %}
+            {% endblock %}
+
+            {% block primary_supplements %}
+            {% endblock %}
+
+            {% block after_primary_supplements %}
+            {% endblock %}
+
+        {% endblock %}
+
+    </div>
+{% endblock %}
+
+<body class="{% block body_classes %}{{ bodyClasses }}{% endblock %}">
+
+{# This block adds a container around the aside #}
+{% block aside_container %}
+{% endblock %}

--- a/tests/Rule/Block/EndblockNameRuleTest.twig
+++ b/tests/Rule/Block/EndblockNameRuleTest.twig
@@ -22,3 +22,19 @@
 {# This block adds a container around the aside #}
 {% block aside_container %}
 {% endblock %}
+
+{% macro test() %}
+{% endmacro %}
+{% macro outer_macro() %}
+    {% macro inner_macro() %}
+    {% endmacro %}
+{% endmacro %}
+
+{% block badges %}
+    {% macro render_badge(text) %}
+        <span class="badge">{{ text }}</span>
+    {% endmacro %}
+
+    {{ _self.render_badge('Live') }}
+    {{ _self.render_badge('Offline') }}
+{% endblock %}

--- a/tests/Rule/Block/NoEndblockNameRuleTest.fixed.twig
+++ b/tests/Rule/Block/NoEndblockNameRuleTest.fixed.twig
@@ -1,0 +1,24 @@
+{% block aside %}
+    <div class="aside">
+
+        {% block aside_inner %}
+
+            {% block before_primary_supplements %}
+            {% endblock %}
+
+            {% block primary_supplements %}
+            {% endblock %}
+
+            {% block after_primary_supplements %}
+            {% endblock %}
+
+        {% endblock %}
+
+    </div>
+{% endblock %}
+
+<body class="{% block body_classes %}{{ bodyClasses }}{% endblock %}">
+
+{# This block adds a container around the aside #}
+{% block aside_container %}
+{% endblock %}

--- a/tests/Rule/Block/NoEndblockNameRuleTest.fixed.twig
+++ b/tests/Rule/Block/NoEndblockNameRuleTest.fixed.twig
@@ -22,3 +22,19 @@
 {# This block adds a container around the aside #}
 {% block aside_container %}
 {% endblock %}
+
+{% macro test() %}
+{% endmacro %}
+{% macro outer_macro() %}
+    {% macro inner_macro() %}
+    {% endmacro %}
+{% endmacro %}
+
+{% block badges %}
+    {% macro render_badge(text) %}
+        <span class="badge">{{ text }}</span>
+    {% endmacro %}
+
+    {{ _self.render_badge('Live') }}
+    {{ _self.render_badge('Offline') }}
+{% endblock %}

--- a/tests/Rule/Block/NoEndblockNameRuleTest.php
+++ b/tests/Rule/Block/NoEndblockNameRuleTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jadu\Style\Twig\Tests\Rules\Block;
+
+use Jadu\Style\Twig\Rule\Block\NoEndblockNameRule;
+use TwigCsFixer\Test\AbstractRuleTestCase;
+
+final class NoEndblockNameRuleTest extends AbstractRuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->checkRule(new NoEndblockNameRule(), [
+            'NoEndblockName.Error:7:16' => 'Unexpected block name "before_primary_supplements" after endblock',
+            'NoEndblockName.Error:10:16' => 'Unexpected block name "primary_supplements" after endblock',
+            'NoEndblockName.Error:13:16' => 'Unexpected block name "after_primary_supplements" after endblock',
+            'NoEndblockName.Error:15:12' => 'Unexpected block name "aside_inner" after endblock',
+            'NoEndblockName.Error:18:4' => 'Unexpected block name "aside" after endblock',
+            'NoEndblockName.Error:20:58' => 'Unexpected block name "body_classes" after endblock',
+            'NoEndblockName.Error:24:4' => 'Unexpected block name "aside_container" after endblock',
+        ]);
+    }
+}

--- a/tests/Rule/Block/NoEndblockNameRuleTest.php
+++ b/tests/Rule/Block/NoEndblockNameRuleTest.php
@@ -19,6 +19,11 @@ final class NoEndblockNameRuleTest extends AbstractRuleTestCase
             'NoEndblockName.Error:18:4' => 'Unexpected block name "aside" after endblock',
             'NoEndblockName.Error:20:58' => 'Unexpected block name "body_classes" after endblock',
             'NoEndblockName.Error:24:4' => 'Unexpected block name "aside_container" after endblock',
+            'NoEndblockName.Error:27:4' => 'Unexpected macro name "test" after endmacro',
+            'NoEndblockName.Error:30:8' => 'Unexpected macro name "inner_macro" after endmacro',
+            'NoEndblockName.Error:31:4' => 'Unexpected macro name "outer_macro" after endmacro',
+            'NoEndblockName.Error:36:8' => 'Unexpected macro name "render_badge" after endmacro',
+            'NoEndblockName.Error:40:4' => 'Unexpected block name "badges" after endblock',
         ]);
     }
 }

--- a/tests/Rule/Block/NoEndblockNameRuleTest.twig
+++ b/tests/Rule/Block/NoEndblockNameRuleTest.twig
@@ -22,3 +22,19 @@
 {# This block adds a container around the aside #}
 {% block aside_container %}
 {% endblock aside_container %}
+
+{% macro test() %}
+{% endmacro test %}
+{% macro outer_macro() %}
+    {% macro inner_macro() %}
+    {% endmacro inner_macro %}
+{% endmacro outer_macro %}
+
+{% block badges %}
+    {% macro render_badge(text) %}
+        <span class="badge">{{ text }}</span>
+    {% endmacro render_badge %}
+
+    {{ _self.render_badge('Live') }}
+    {{ _self.render_badge('Offline') }}
+{% endblock badges %}

--- a/tests/Rule/Block/NoEndblockNameRuleTest.twig
+++ b/tests/Rule/Block/NoEndblockNameRuleTest.twig
@@ -1,0 +1,24 @@
+{% block aside %}
+    <div class="aside">
+
+        {% block aside_inner %}
+
+            {% block before_primary_supplements %}
+            {% endblock before_primary_supplements %}
+
+            {% block primary_supplements %}
+            {% endblock primary_supplements %}
+
+            {% block after_primary_supplements %}
+            {% endblock after_primary_supplements %}
+
+        {% endblock aside_inner %}
+
+    </div>
+{% endblock aside %}
+
+<body class="{% block body_classes %}{{ bodyClasses }}{% endblock body_classes %}">
+
+{# This block adds a container around the aside #}
+{% block aside_container %}
+{% endblock aside_container %}

--- a/tests/Rule/Filter/NoFilterTagRuleTest.fixed.twig
+++ b/tests/Rule/Filter/NoFilterTagRuleTest.fixed.twig
@@ -1,0 +1,3 @@
+{% apply lower|escape('html') %}
+    <strong>UPPERCASE TEXT</strong>
+{% endapply %}

--- a/tests/Rule/Filter/NoFilterTagRuleTest.php
+++ b/tests/Rule/Filter/NoFilterTagRuleTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jadu\Style\Twig\Tests\Rules\Filter;
+
+use Jadu\Style\Twig\Rule\Filter\NoFilterTagRule;
+use TwigCsFixer\Test\AbstractRuleTestCase;
+
+final class NoFilterTagRuleTest extends AbstractRuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->checkRule(new NoFilterTagRule(), [
+            'NoFilterTag.Error:1:4' => 'Unexpected "filter" tag',
+            'NoFilterTag.Error:3:4' => 'Unexpected "endfilter" tag',
+        ]);
+    }
+}

--- a/tests/Rule/Filter/NoFilterTagRuleTest.twig
+++ b/tests/Rule/Filter/NoFilterTagRuleTest.twig
@@ -1,0 +1,3 @@
+{% filter lower|escape('html') %}
+    <strong>UPPERCASE TEXT</strong>
+{% endfilter %}

--- a/tests/Rule/Filter/NoSpacelessTagRuleTest.fixed.twig
+++ b/tests/Rule/Filter/NoSpacelessTagRuleTest.fixed.twig
@@ -1,0 +1,2 @@
+{% apply spaceless %}
+{% endapply %}

--- a/tests/Rule/Filter/NoSpacelessTagRuleTest.php
+++ b/tests/Rule/Filter/NoSpacelessTagRuleTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jadu\Style\Twig\Tests\Rules\Filter;
+
+use Jadu\Style\Twig\Rule\Filter\NoSpacelessTagRule;
+use TwigCsFixer\Test\AbstractRuleTestCase;
+
+final class NoSpacelessTagRuleTest extends AbstractRuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->checkRule(new NoSpacelessTagRule(), [
+            'NoSpacelessTag.Error:1:4' => 'Unexpected "spaceless" tag',
+            'NoSpacelessTag.Error:2:4' => 'Unexpected "endspaceless" tag',
+        ]);
+    }
+}

--- a/tests/Rule/Filter/NoSpacelessTagRuleTest.twig
+++ b/tests/Rule/Filter/NoSpacelessTagRuleTest.twig
@@ -1,0 +1,2 @@
+{% spaceless %}
+{% endspaceless %}

--- a/tests/Rule/Punctuation/PunctuationSpacingRuleTest.fixed.twig
+++ b/tests/Rule/Punctuation/PunctuationSpacingRuleTest.fixed.twig
@@ -1,0 +1,9 @@
+{{ 1..10 }}
+{{ foo.bar }}
+{{ (foo) }}
+{{ { 'foo': 'bar', 'baz': 'qux' } }}
+{% set a = [1, 2, 4] %}
+{{ [{ a: 1, },] }}
+{{ 'test'[1:2] }}
+{% types { foo: 'int', bar ?: 'string' } %}
+{% set emptyHash = {} %}

--- a/tests/Rule/Punctuation/PunctuationSpacingRuleTest.php
+++ b/tests/Rule/Punctuation/PunctuationSpacingRuleTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jadu\Style\Twig\Tests\Rules\Punctuation;
+
+use Jadu\Style\Twig\Rule\Punctuation\PunctuationSpacingRule;
+use TwigCsFixer\Test\AbstractRuleTestCase;
+
+final class PunctuationSpacingRuleTest extends AbstractRuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->checkRule(new PunctuationSpacingRule(), [
+            'PunctuationSpacing.After:3:4' => 'Expecting 0 whitespace after "("; found 1.',
+            'PunctuationSpacing.Before:3:10' => 'Expecting 0 whitespace before ")"; found 1.',
+            'PunctuationSpacing.After:4:4' => 'Expecting 1 whitespace after "{"; found 0.',
+            'PunctuationSpacing.Before:4:11' => 'Expecting 0 whitespace before ":"; found 1.',
+            'PunctuationSpacing.Before:4:19' => 'Expecting 0 whitespace before ","; found 1.',
+            'PunctuationSpacing.Before:4:27' => 'Expecting 0 whitespace before ":"; found 1.',
+            'PunctuationSpacing.Before:4:34' => 'Expecting 1 whitespace before "}"; found 0.',
+            'PunctuationSpacing.After:5:12' => 'Expecting 0 whitespace after "["; found 1.',
+            'PunctuationSpacing.Before:5:16' => 'Expecting 0 whitespace before ","; found 1.',
+            'PunctuationSpacing.Before:5:20' => 'Expecting 0 whitespace before ","; found 1.',
+            'PunctuationSpacing.Before:5:24' => 'Expecting 0 whitespace before "]"; found 1.',
+            'PunctuationSpacing.After:6:5' => 'Expecting 1 whitespace after "{"; found 0.',
+            'PunctuationSpacing.Before:6:15' => 'Expecting 0 whitespace before "]"; found 1.',
+            'PunctuationSpacing.After:8:10' => 'Expecting 1 whitespace after "{"; found 0.',
+            'PunctuationSpacing.Before:8:26' => 'Expecting 1 whitespace before "?:"; found 0.',
+            'PunctuationSpacing.Before:8:37' => 'Expecting 1 whitespace before "}"; found 0.',
+            'PunctuationSpacing.After:9:20' => 'Expecting 0 whitespace after "{"; found 1.',
+            'PunctuationSpacing.Before:9:22' => 'Expecting 0 whitespace before "}"; found 1.',
+        ]);
+    }
+}

--- a/tests/Rule/Punctuation/PunctuationSpacingRuleTest.twig
+++ b/tests/Rule/Punctuation/PunctuationSpacingRuleTest.twig
@@ -1,0 +1,9 @@
+{{ 1..10 }}
+{{ foo.bar }}
+{{ ( foo ) }}
+{{ {'foo' : 'bar' , 'baz' : 'qux'} }}
+{% set a = [ 1 , 2 , 4 ] %}
+{{ [{a: 1, }, ] }}
+{{ 'test'[1:2] }}
+{% types {foo: 'int', bar?: 'string'} %}
+{% set emptyHash = { } %}


### PR DESCRIPTION
# Add support for Twig ^3.21

## Summary

This PR adds support for all previously unsupported versions of Twig 3 (>= 3.21.0) and Twig 4, and removes support for Twig 2.

Unit tests are introduced to verify the correctness of each rule and document their intended behaviours.

## Changes

- Added support for modern versions of Twig 3 and Twig 4
- Dropped support for Twig 2
- Applied vincentlanglet/twig-cs-fixer compatibility changes for 3.0 and 4.0
- Added unit tests
- Enforced punctuation spacing rules for `?:` operator

Fixes #5 